### PR TITLE
Auto-assign active Servizio when clocking in with /entrata

### DIFF
--- a/src/tg_bot/bot.py
+++ b/src/tg_bot/bot.py
@@ -23,6 +23,7 @@ from telegram.ext import (
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 
 from .models import LoginToken, TelegramUser, WebLoginRequest
 from servizio.models import (
@@ -278,17 +279,37 @@ async def clock_in(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         )
         return
 
-    # Create new time entry
-    entry = await Timbratura.objects.acreate(fkvolontario=volontario)
+    # Check if there is an active Servizio right now
+    now = timezone.now()
+    active_servizio = await Servizio.objects.filter(
+        data_ora__lte=now,
+    ).filter(
+        Q(data_ora_fine__gte=now) | Q(data_ora_fine__isnull=True)
+    ).order_by("-data_ora").afirst()
+
+    # Create new time entry, linked to the active servizio if any
+    entry = await Timbratura.objects.acreate(
+        fkvolontario=volontario,
+        fkservizio=active_servizio,
+    )
 
     clock_out_keyboard = InlineKeyboardMarkup(
         [[InlineKeyboardButton("🔴 Registra uscita", callback_data="clock_out")]]
     )
-    await update.message.reply_text(
-        f"✅ Entrata registrata alle {timezone.localtime(entry.clock_in):%H:%M}.\n\n"
-        f"Buon lavoro!",
-        reply_markup=clock_out_keyboard,
-    )
+    if active_servizio:
+        await update.message.reply_text(
+            f"✅ Entrata registrata alle {timezone.localtime(entry.clock_in):%H:%M} "
+            f"per il servizio *{active_servizio.nome}*.\n\n"
+            f"Buon lavoro!",
+            parse_mode="Markdown",
+            reply_markup=clock_out_keyboard,
+        )
+    else:
+        await update.message.reply_text(
+            f"✅ Entrata registrata alle {timezone.localtime(entry.clock_in):%H:%M}.\n\n"
+            f"Buon lavoro!",
+            reply_markup=clock_out_keyboard,
+        )
 
 
 async def clock_out(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -874,8 +895,6 @@ async def handle_clock_out_callback(
 
 async def close_expired_polls(context: ContextTypes.DEFAULT_TYPE) -> None:
     """Close polls that have reached their poll_close_date or are starting within 12 hours."""
-    from django.db.models import Q
-
     now = timezone.now()
     cutoff = now + timedelta(hours=12)
 


### PR DESCRIPTION
If a volunteer runs /entrata while a Servizio is ongoing (data_ora <= now <= data_ora_fine, or no end time set), the Timbratura is automatically linked to that Servizio. The confirmation message tells the volunteer which service they have been clocked into.

Also hoisted the local Q import inside close_expired_polls to the module level.

https://claude.ai/code/session_01WFV1ycysLeCMAYTyVA9FBc